### PR TITLE
[scmake] make scmake search for compile_commands.json

### DIFF
--- a/scmake
+++ b/scmake
@@ -87,7 +87,7 @@ def cmake(out_dir_p: Path):
     return True
 
 
-def scmake(out_dir_p: Path):
+def scmake(out_dir_p: Path, cmake_out_p: Path):
     ''' Create preprocessed files and move them into the output directory
 
     Args:
@@ -97,9 +97,14 @@ def scmake(out_dir_p: Path):
     '''
 
     cwd = Path().cwd()
-
-    with open("./compile_commands.json", "r") as f:
-        compilation_db = json.load(f)
+    compile_command_path = Path("./compile_commands.json")
+    if Path.is_file(compile_command_path):
+        with open(str(compile_command_path), "r") as f:
+            compilation_db = json.load(f)
+    else:
+        compile_command_path = cmake_out_p / "compile_commands.json"
+        with open(str(compile_command_path), "r") as f:
+            compilation_db = json.load(f)
 
     # create output directory
     if not mkdir_safe(out_dir_p):
@@ -134,8 +139,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--cmake", action="store_true",
                         default=False, help="cmake under CMAKE_OUT")
-    parser.add_argument("--cmake-out", default="build",
-                        help="set cmake directory (default: build)")
+    parser.add_argument("--cmake-out", default="tmp_out",
+                        help="set cmake directory (default: tmp_out)")
     parser.add_argument("--out", const="sparrow", default="sparrow",
                         nargs="?", help="initialize output directory (default: sparrow)")
 
@@ -147,4 +152,4 @@ if __name__ == "__main__":
     if args.cmake:  # only cmake
         sys.exit(-1)
 
-    scmake(scmake_out_p)
+    scmake(scmake_out_p, cmake_out_p)


### PR DESCRIPTION
scmake를 사용하기 위해서는 cmake에서 나오는 `compile_command.json`파일이 필요하다.
기존에는 현재 위치한 디렉토리 내에서에서 해당 파일을 읽게 되어있었는데 ex) `./compile_command.json`
해당 파일의 위치는 프로젝트에 따라 cmake_out 디렉토리에 생성되는 경우가 존재한다. 
이러한 번거로움을 자동화 하기위해 

`./compile_command.json`이 존재하지 않으면
`<cmake_out>/compile_command.json`에서 파일을 읽도록 패치하였다.